### PR TITLE
Improve address parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 2. Click "Start" button to begin packet capture
 3. Real-time packet information will be displayed
 4. Statistics are automatically updated
-5. Frames without IP information will show `Unknown` for address fields
+5. IPv6 and ARP addresses are also detected. If no address information is present, `Unknown` will be displayed.
 
 ## Configuration Options
 


### PR DESCRIPTION
## Summary
- collect IPv6 and ARP address fields from tshark
- parse additional address data to avoid `Unknown`
- document IPv6 and ARP support in README

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68610a748cc4833290a10b00d718c0db