### PR TITLE
Update viz view layout and line style

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -577,10 +577,10 @@
     </div>
     </div>
 
-    <div id="vizView" class="view">
+        <div id="vizView" class="view">
         <div class="container viz-container">
-            <canvas id="timeChart" height="300"></canvas>
             <svg id="chordDiagram" width="600" height="600"></svg>
+            <canvas id="timeChart" height="300"></canvas>
         </div>
     </div>
 
@@ -1458,8 +1458,8 @@
                 .selectAll('path')
                 .data(chord)
                 .join('path')
-                .attr('stroke', d => color(d.source.index))
-                .attr('stroke-width', d => 1 + Math.sqrt(d.source.value))
+                .attr('stroke', '#888')
+                .attr('stroke-width', 1.5)
                 .attr('d', d => link({
                     source: { angle: (d.source.startAngle + d.source.endAngle) / 2, radius: innerRadius },
                     target: { angle: (d.target.startAngle + d.target.endAngle) / 2, radius: innerRadius }


### PR DESCRIPTION
## Summary
- move traffic chart below the chord diagram
- use a constant stroke color and width for host connection lines

## Testing
- `cargo check`
- `cargo test -- --list`

------
https://chatgpt.com/codex/tasks/task_b_68610d79a8508332bb9ea0d422a72dfb