### PR TITLE
Add configuration tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,49 @@ struct PacketInfo {
     info: String,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::State;
+    use axum::Json;
+
+    #[test]
+    fn test_parse_tshark_line_basic() {
+        let line = "1616161616.123|192.168.0.1|192.168.0.2|||||eth:ip:tcp:tls|60|Example";
+        let packet = parse_tshark_line(line).expect("packet parsed");
+        assert_eq!(packet.src_ip, "192.168.0.1");
+        assert_eq!(packet.dst_ip, "192.168.0.2");
+        assert_eq!(packet.protocol, "TCP");
+        assert_eq!(packet.sub_protocol.as_deref(), Some("TLS"));
+        assert_eq!(packet.length, 60);
+        assert_eq!(packet.info, "Example");
+    }
+
+    #[tokio::test]
+    async fn test_set_filter_handler_updates_filter() {
+        let stats = Arc::new(Mutex::new(PacketStats {
+            total_packets: 0,
+            protocols: HashMap::new(),
+            top_sources: HashMap::new(),
+            top_destinations: HashMap::new(),
+        }));
+
+        let filter = Arc::new(Mutex::new(FilterConfig { tshark_filter: None }));
+        let (tx, _) = broadcast::channel(1);
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+
+        let new_filter = FilterConfig { tshark_filter: Some("tcp".to_string()) };
+        let state = State((stats, filter.clone(), tx, cmd_tx));
+        let result = set_filter_handler(state, Json(new_filter.clone()))
+            .await
+            .expect("handler ok");
+
+        assert_eq!(result.0.tshark_filter, Some("tcp".to_string()));
+        assert_eq!(filter.lock().unwrap().tshark_filter, Some("tcp".to_string()));
+        assert!(matches!(cmd_rx.try_recv(), Ok(CaptureCommand::Restart)));
+    }
+}
+
 const PROTOCOLS: [&str; 9] = [
     "TCP",
     "UDP",


### PR DESCRIPTION
## Summary
- add unit tests for parsing tshark lines and filter updates

## Testing
- `cargo fmt -- --check` *(fails: 'cargo-fmt' is not installed)*
- `cargo build --verbose`
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_b_686268e7a50083329d8f9845da49802b